### PR TITLE
SE-1023 iOS: discover device services API

### DIFF
--- a/example/lib/bluetooth_devices.screen.dart
+++ b/example/lib/bluetooth_devices.screen.dart
@@ -1,15 +1,14 @@
 import "dart:async";
-
+import "package:flutter_mobx/flutter_mobx.dart";
 import "package:flutter/material.dart";
-import 'package:flutter_amazon_freertos_plugin_example/stores/bluetooth/bluetooth.store.dart';
+import "package:flutter_amazon_freertos_plugin_example/stores/bluetooth/bluetooth.store.dart";
 import "package:flutter_amazon_freertos_plugin_example/stores/cognito/cognito.store.dart";
 import "package:provider/provider.dart";
+import "package:flutter_amazon_freertos_plugin/flutter_amazon_freertos_plugin.dart";
 
 class BluetoothDevicesScreen extends StatelessWidget {
     @override
     Widget build(BuildContext context) {
-        Timer devicesNearbyTimer;
-
         final cognitoStore = Provider.of<CognitoStore>(context);
         final bluetoothStore = Provider.of<BluetoothStore>(context);
 
@@ -26,62 +25,73 @@ class BluetoothDevicesScreen extends StatelessWidget {
         Future<void> _stopScanning() async {
             try {
                 await bluetoothStore.stopScanning();
-                
-                if(!devicesNearbyTimer.isActive) return;
-                devicesNearbyTimer.cancel();
             } catch (e) {
                 print("Error: Failed to _stopScanning()");
                 print(e);
             }
         }
 
-        void _getDevicesNearby() {
-            // Nearby devices list are usually cached. 
-            // If there is a new device discovered nearby, it is added to the list
-            // automatically. This is not the the case if the device that was previously
-            // discovered and in list turned off (for any reason). It does not get removed
-            // from list automatically.
-            // rescanForDevices() freshes the device list from the platform side. 
-
-            devicesNearbyTimer = Timer.periodic(Duration(seconds: 5), (timer) async {
-                await bluetoothStore.getDevicesNearby();
-            });
-        }
-
         Future<void> _startScanning() async {
             await bluetoothStore.startScanning();
-            _getDevicesNearby();
+            await bluetoothStore.getDevicesNearby();
         }
 
-        print("BLE devices nearby");
-        print("${bluetoothStore.devicesNearby}");
+        Widget _buildDeviceContainer(BuildContext context, int index) {
+            FreeRTOSDevice device = bluetoothStore.devicesNearby[index];
 
-        return Scaffold(
-            appBar: AppBar(
-                title: Text("BLE Devices"),
-                actions: <Widget>[
-                    IconButton(
-                        icon: Icon(Icons.refresh),
-                        tooltip: "Rescan for devices",
-                        onPressed: bluetoothStore.rescan,
-                    )
-                ],
-            ),
-            body: Container(
-                padding: EdgeInsets.all(10),
-                child: Column(
-                    children: <Widget>[
-                        Text("Bluetooth state: $bluetoothStore.bluetoothState\n"),
-                        Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            return InkWell(
+                onTap: () async {
+                    device.connect();
+                    var services = await device.discoverServices();
+                    print(services);
+                },
+                splashColor: Colors.amberAccent,
+                child: Container(
+                    height: 50,
+                    color: Colors.blue,
+                    child: Center(child: Text("${device.name}"))
+                )
+            );
+        }
+
+        return Observer(name: "BluetoothDevices",
+                builder: (_) => Scaffold(
+                    appBar: AppBar(
+                        title: Text("BLE Devices"),
+                        actions: <Widget>[
+                            IconButton(
+                                icon: Icon(Icons.refresh),
+                                tooltip: "Rescan for devices",
+                                onPressed: bluetoothStore.rescan,
+                            )
+                        ],
+                    ),
+                    body: Container(
+                        padding: EdgeInsets.all(10),
+                        child: Column(
                             children: <Widget>[
-                                OutlineButton(child: Text("Start Scan"), onPressed: _startScanning),
-                                OutlineButton(child: Text("Stop Scan"), onPressed: _stopScanning),
-                                OutlineButton(child: Text("Sign out"), onPressed: _onPressedSignOut),
-                            ]
-                        )
-                    ],
-                ),
+                                Text("Bluetooth state: $bluetoothStore.bluetoothState\n"),
+                                Row(
+                                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                                    children: <Widget>[
+                                        OutlineButton(child: Text("Start Scan"), onPressed: _startScanning),
+                                        OutlineButton(child: Text("Stop Scan"), onPressed: _stopScanning),
+                                        OutlineButton(child: Text("Sign out"), onPressed: _onPressedSignOut),
+                                    ]
+                                ),
+                                Expanded(
+                                    flex: 1,
+                                    child: Container(
+                                        margin: EdgeInsets.only(top: 10),
+                                        child: ListView.builder(
+                                            padding: EdgeInsets.all(8),
+                                            itemCount: bluetoothStore.devicesNearby.length,
+                                            itemBuilder: _buildDeviceContainer),
+                                    ),
+                                )
+                            ],
+                        ),
+                    ),
             ),
         );
     }

--- a/ios/Classes/FreeRTOSBluetooth.swift
+++ b/ios/Classes/FreeRTOSBluetooth.swift
@@ -55,7 +55,7 @@ class FreeRTOSBluetooth {
         discoveredDevicesTimer[id]?.invalidate()
         discoveredDevicesTimer.removeValue(forKey: id)
     }
-    
+        
     func connectToDeviceId(call: FlutterMethodCall, result: @escaping FlutterResult) {
         let args = call.arguments as! [String: Any?]
         let deviceId = args["id"] as! String
@@ -77,13 +77,17 @@ class FreeRTOSBluetooth {
         }
     }
     
-    func listServices(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    func listServicesForDeviceId(call: FlutterMethodCall, result: @escaping FlutterResult) {
         let args = call.arguments as! [String: Any?]
         let deviceId = args["id"] as! String
         
         guard let deviceUUID = UUID(uuidString: deviceId) else { return }
         if let device: AmazonFreeRTOSDevice = awsFreeRTOSManager.devices[deviceUUID] {
-            result(device.peripheral.services)
+            var services: [Any] = []
+            for service in device.peripheral.services ?? [] {
+                services.append(dumpFreeRTOSDeviceServiceInfo(service))
+            }
+            result(services)
         }
     }
     

--- a/ios/Classes/SwiftFlutterAmazonFreertosPlugin.swift
+++ b/ios/Classes/SwiftFlutterAmazonFreertosPlugin.swift
@@ -21,7 +21,7 @@ public class SwiftFlutterAmazonFreeRTOSPlugin: NSObject, FlutterPlugin {
                 "disconnectFromDeviceId": plugin.disconnectFromDeviceId,
                 "discoverDevicesOnListen": plugin.discoverDevicesOnListen,
                 "discoverDevicesOnCancel": plugin.discoverDevicesOnCancel,
-                "listServices": plugin.listServices,
+                "listServicesForDeviceId": plugin.listServicesForDeviceId,
                 "listDiscoveredDevices": plugin.listDiscoveredDevices,
                 "readCharacteristic": plugin.readCharacteristic,
                 "readDescriptor": plugin.readDescriptor,

--- a/ios/Classes/serializer.swift
+++ b/ios/Classes/serializer.swift
@@ -2,20 +2,70 @@ import AmazonFreeRTOS
 import CoreBluetooth
 
 
-func dumpFreeRTOSDeviceInfo(_ device: AmazonFreeRTOSDevice) -> [Any] {
+func dumpFreeRTOSDeviceInfo(_ device: AmazonFreeRTOSDevice) -> [String: Any] {
     let deviceState = _deviceStateEnum.firstIndex(of: device.peripheral.state)!
 
     return [
-        device.peripheral.identifier.uuidString,
-        device.advertisementData?["kCBAdvDataLocalName"] as? String ?? device.peripheral.name,
-        deviceState,
-        device.reconnect,
-        device.RSSI?.intValue ?? 0,
-        device.certificateId ?? "",
-        device.brokerEndpoint ?? "",
-        device.mtu ?? 0,
+        "id": device.peripheral.identifier.uuidString,
+        "name": device.advertisementData?["kCBAdvDataLocalName"] as? String ?? device.peripheral.name!,
+        "state": deviceState,
+        "reconnect": device.reconnect,
+        "rssi": device.RSSI?.intValue ?? 0,
+        "certificateId": device.certificateId ?? "",
+        "brokerEndpoint": device.brokerEndpoint ?? "",
+        "mtu": device.mtu ?? 0,
     ]
 }
+
+func dumpFreeRTOSDeviceServiceInfo(_ service: CBService) -> [String: Any] {
+    var primaryServiceMap: [String: Any] = ["id": service.uuid.uuidString, "isPrimary": service.isPrimary]
+    primaryServiceMap["characteristics"] = dumpServiceCharacteristics(service)
+    primaryServiceMap["includedServices"] = []
+
+    // Loop through included services if exists
+    var includedServiceList: [Any] = []
+    guard let includedServices = service.includedServices else { return primaryServiceMap }
+    for s in includedServices {
+        includedServiceList.append([s.uuid.uuidString, s.isPrimary, dumpServiceCharacteristics(s)])
+    }
+    primaryServiceMap["includedServices"] = includedServiceList
+
+    return primaryServiceMap
+}
+
+func dumpServiceCharacteristics(_ service: CBService) -> [[String: Any]] {
+    var result: [[String: Any]] = []
+    for c in service.characteristics ?? [] {
+        let characteristicProperty = _characteristicPropertiesEnum.firstIndex(of: c.properties)
+        result.append([
+            "id": c.uuid.uuidString,
+            "isNotifying": c.isNotifying,
+            "property": characteristicProperty ?? -1,
+            "value": c.value,
+            "serviceId": c.service.uuid.uuidString,
+        ])
+    }
+    return result
+}
+
+//func dumpBlueoothDescriptor(_ descriptor: CBDescriptor) -> [[String: Any]] {
+//    return [
+//        "id": descriptor.value
+//    ]
+//}
+
+let _characteristicPropertiesEnum = [
+    CBCharacteristicProperties.broadcast,
+    CBCharacteristicProperties.read,
+    CBCharacteristicProperties.writeWithoutResponse,
+    CBCharacteristicProperties.write,
+    CBCharacteristicProperties.notify,
+    CBCharacteristicProperties.indicate,
+    CBCharacteristicProperties.authenticatedSignedWrites,
+    CBCharacteristicProperties.extendedProperties,
+    CBCharacteristicProperties.notifyEncryptionRequired,
+    CBCharacteristicProperties.indicateEncryptionRequired
+]
 
 let _deviceStateEnum = [
     CBPeripheralState.connected,

--- a/lib/flutter_amazon_freertos_plugin.dart
+++ b/lib/flutter_amazon_freertos_plugin.dart
@@ -1,6 +1,7 @@
 library flutter_amazon_freertos_plugin;
 
 import "dart:async";
+import 'dart:convert';
 import "package:flutter/services.dart";
 import "package:logging/logging.dart";
 import "package:plugin_scaffold/plugin_scaffold.dart";

--- a/lib/src/flutter_amazon_freertos_plugin.dart
+++ b/lib/src/flutter_amazon_freertos_plugin.dart
@@ -45,7 +45,7 @@ class FlutterAmazonFreeRTOSPlugin {
         final List devices = await channel.invokeListMethod("listDiscoveredDevices");
         return List<FreeRTOSDevice>.from(
             devices.map((device) {
-                return FreeRTOSDevice.fromMsg(device);
+                return FreeRTOSDevice.fromJson(device);
             })
         );
     }


### PR DESCRIPTION
JIRA: SE-1023

* add the ability to retrieve ble device services
* replaced lists with maps to send data from iOS to Flutter plugin

Example app: show nearby devices in a list

### Example app issues
* You have to tap the "start scan" btn twice in order for the nearby ble devices to show up
* when you click on a device, it will try to connect. If the connection is successful, the second tap will print the services in the console.
